### PR TITLE
Using modified RSA package

### DIFF
--- a/lib/deterministics.go
+++ b/lib/deterministics.go
@@ -1,7 +1,7 @@
 package deterministics
 
 import (
-	"crypto/rsa"
+	rsa "github.com/acalatrava/deterministicrsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/asn1"


### PR DESCRIPTION
By using this copy of the `crypto/rsa` package it will always produce the same output instead of having 50% chance to produce two different outputs (https://github.com/joekir/deterministics/issues/2)